### PR TITLE
Added lock to not have duplicate calls to refresh token

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Lynk & Co Home Assistant Custom Component
 
+## :warning: **Warning**: Use of this integration with Lynk & Co's services might lead to your account being blocked. Use at your own risk.
+
 ## Introduction
 This custom component allows Home Assistant users to integrate and control their Lynk & Co vehicles directly from Home Assistant.
 It provides the functionality for multiple users to control pre climate and sensor monitoring.

--- a/custom_components/lynkco/manifest.json
+++ b/custom_components/lynkco/manifest.json
@@ -12,5 +12,5 @@
         "requests>=2.31.0",
         "pkce>=1.0.3"
     ],
-    "version": "1.1.1"
+    "version": "1.1.2"
 }

--- a/release-notes
+++ b/release-notes
@@ -1,2 +1,2 @@
-1.1.1
-Increased time between polling for expected state
+1.1.2
+Removed duplicate call for refresh token and added warning text at the top of readme


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a warning about potential account blocking when using Lynk & Co's services.
- **Bug Fixes**
  - Transitioned from increasing time between polling to removing a duplicate call for the refresh token.
- **New Features**
  - Updated version number to "1.1.2" in the manifest.
- **Refactor**
  - Improved token management to enhance security and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->