### PR TITLE
Increased default timeout for auto updater

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ Configure this integration through the Home Assistant UI.
 3. Follow the on-screen instructions to enter your vehicle details and complete the setup.
 
 ## Features and Usage
+The device will auto-update once every other hour by default and is configurable in the options flow to update between 1-24 hours per update.
+The system seem to be more stable with longer intervals, use force_update_data service to update when needed instead. The device will also
+update itself when expecting a new state after a service has been called.
 
 ### Services
 This component offers various services to interact with your vehicle, including:

--- a/custom_components/lynkco/__init__.py
+++ b/custom_components/lynkco/__init__.py
@@ -85,7 +85,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 async def options_update_listener(hass: HomeAssistant, entry: ConfigEntry):
     """Handle options update."""
 
-    update_interval_minutes = max(30, entry.options.get(CONFIG_SCAN_INTERVAL_KEY, 60))
+    update_interval_minutes = max(60, entry.options.get(CONFIG_SCAN_INTERVAL_KEY, 240))
+    _LOGGER.debug(f"Will update every: {update_interval_minutes} min")
 
     # Retrieve and update the coordinator's interval
     coordinator = hass.data[DOMAIN][entry.entry_id][COORDINATOR]
@@ -197,7 +198,7 @@ async def safely_remove_service(hass: HomeAssistant, domain: str, service: str):
 
 
 async def setup_data_coordinator(hass: HomeAssistant, entry: ConfigEntry):
-    update_interval_minutes = max(30, entry.options.get(CONFIG_SCAN_INTERVAL_KEY, 60))
+    update_interval_minutes = max(60, entry.options.get(CONFIG_SCAN_INTERVAL_KEY, 240))
     _LOGGER.debug(f"Will update every: {update_interval_minutes} min")
     """Setup the data update coordinator."""
     coordinator = DataUpdateCoordinator(

--- a/custom_components/lynkco/config_flow.py
+++ b/custom_components/lynkco/config_flow.py
@@ -197,8 +197,10 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 ): bool,
                 vol.Required(
                     CONFIG_SCAN_INTERVAL_KEY,
-                    default=self.config_entry.options.get(CONFIG_SCAN_INTERVAL_KEY, 60),
-                ): vol.All(vol.Coerce(int), vol.Range(min=30, max=1440)),
+                    default=self.config_entry.options.get(
+                        CONFIG_SCAN_INTERVAL_KEY, 120
+                    ),
+                ): vol.All(vol.Coerce(int), vol.Range(min=60, max=1440)),
             }
         )
 

--- a/custom_components/lynkco/expected_state_monitor.py
+++ b/custom_components/lynkco/expected_state_monitor.py
@@ -72,7 +72,7 @@ class ExpectedStateMonitor:
 
     async def monitor_states(self, hass, entry):
         """Monitor expected states and update them continuously."""
-        poll_time = 3
+        poll_time = 5
         try:
             while True:
                 await asyncio.sleep(poll_time)
@@ -83,7 +83,7 @@ class ExpectedStateMonitor:
                     current_states = coordinator.data
                     if self.check_and_update_states(current_states):
                         break
-                poll_time = min(30, poll_time + 5)
+                poll_time = min(30, poll_time + 10)
         finally:
             self.loop_running = False
 

--- a/custom_components/lynkco/manifest.json
+++ b/custom_components/lynkco/manifest.json
@@ -12,5 +12,5 @@
         "requests>=2.31.0",
         "pkce>=1.0.3"
     ],
-    "version": "1.2.0"
+    "version": "1.2.1"
 }

--- a/release-notes
+++ b/release-notes
@@ -1,2 +1,2 @@
-1.2.0
-Added re-authentication flow
+1.2.1
+Increased default timeout for auto updater


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced configurable auto-update intervals for devices, allowing settings between 1-24 hours.
- **Enhancements**
	- Increased default auto-update interval to enhance stability.
	- Extended polling intervals for state monitoring to improve performance.
- **Documentation**
	- Updated version number to 1.2.1 in release documentation.
- **Bug Fixes**
	- Adjusted minimum update interval settings to prevent overly frequent updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->