### PR TITLE
Added dark hours to options flow to set when automatic updates should be disabled

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Read release notes
         id: release-notes
         run: |
-          BODY=$(tail -n +2 release-notes)
+          BODY=$(tail -n +2 release-notes | tr '\n' ' ')
           echo "::set-output name=body::$BODY"
 
       - name: Create GitHub Release

--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ Options can be configured through the Options Flow in the Home Assistant UI:
    - Set the start and end times for "dark hours" to limit automatic data updates during certain hours.
 
 ## Features and Usage
-The device will auto-update once every other hour by default and is configurable in the options flow to update between 1-24 hours per update.
-The system seem to be more stable with longer intervals, use force_update_data service to update when needed instead. The device will also
+The device will auto-update once every other hour by default and is configurable in the options flow to update every 1-24 hours.
+The system seems to be more stable with longer intervals, use force_update_data service to update when needed instead. The device will also
 update itself when expecting a new state after a service has been called.
 
 ### Services

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This has been tested on european models only.
   - [Installing the Integration](#installing-the-integration)
 - [Configuration](#configuration)
   - [Initial Setup](#initial-setup)
+  - [Options Flow](#options-flow)
 - [Features and Usage](#features-and-usage)
   - [Services](#services)
   - [Entities](#entities)
@@ -52,6 +53,16 @@ Configure this integration through the Home Assistant UI.
 2. Click on "Add Integration" and search for "Lynk & Co".
 3. Follow the on-screen instructions to enter your vehicle details and complete the setup.
 
+### Options Flow
+Options can be configured through the Options Flow in the Home Assistant UI:
+
+1. Navigate to Configuration > Integrations.
+2. Find the Lynk & Co integration and click "Configure".
+3. Adjust settings such as scan interval and experimental features:
+   - Enable or disable experimental features.
+   - Configure the scan interval (in minutes) to control how frequently your vehicle's data is updated.
+   - Set the start and end times for "dark hours" to limit automatic data updates during certain hours.
+
 ## Features and Usage
 The device will auto-update once every other hour by default and is configurable in the options flow to update between 1-24 hours per update.
 The system seem to be more stable with longer intervals, use force_update_data service to update when needed instead. The device will also
@@ -62,14 +73,15 @@ This component offers various services to interact with your vehicle, including:
 - `start_climate` / `stop_climate`: Starts or stops the climate control system.
 - `lock_doors` / `unlock_doors`: Locks or unlocks the doors.
 - `start_flash_lights` / `stop_flash_lights`: Activates or deactivates hazard lights.
-- `start_engine` / `stop_engine`: Starts or stops the engine. (Note: This feature is experimental and undocumented by Lynk & Co.)
+- `start_engine` / `stop_engine`: Starts or stops the engine. (Note: This feature is experimental and is not documented by Lynk & Co.)
 - `force_update_data`: Forcing update data from the vehicle, bypassing night limit.
 - `refresh_tokens`: Refreshes authentication tokens, this should not be needed, handled automatically.
 
 #### Detailed Service Information
 
 - **start_engine / stop_engine**: This service allows you to remotely start or stop your vehicle's engine. It's an experimental feature not officially supported by the Lynk & Co app.
-Use with caution, as it may not always perform as expected. My observations are that the EV engine will be started and climate will be set to HI, this service have not been tested without sufficient EV battery.
+Use with caution, as it may not always perform as expected. My observations are that the EV engine will be started and climate will be set to your latest configuration in the car.
+This has not been tested without sufficient EV battery.
 
 ### Entities
 The integration creates entities for comprehensive monitoring and control of the Lynk & Co vehicle, including both sensors and binary sensors.
@@ -97,7 +109,7 @@ Sensors provide detailed information about various aspects of the vehicle's stat
 Binary sensors indicate specific vehicle states that have a true or false condition. These include:
 
 - **Pre Climate Active**: Indicates whether the pre-climate control system is active, ensuring the vehicle's interior is at a comfortable temperature before you enter. It uses the icon `mdi:air-conditioner` to visually represent this feature in the Home Assistant UI.
-- **Vehicle is Running**: Shows if the vehicle's engine is currently running. This sensor is crucial for understanding the immediate operational state of your vehicle and uses the `mdi:engine` icon for easy identification.
+- **Vehicle is Running**: Shows if the vehicle's engine is currently running. This sensor is on if car is running either normally or by start engine service.
 
 For a comprehensive list of all entities, including detailed descriptions and additional sensors, please refer to [Detailed Entities Information](entities.md).
 

--- a/custom_components/lynkco/config_flow.py
+++ b/custom_components/lynkco/config_flow.py
@@ -7,6 +7,8 @@ from homeassistant.data_entry_flow import FlowResult
 
 from .const import (
     CONFIG_2FA_KEY,
+    CONFIG_DARK_HOURS_END,
+    CONFIG_DARK_HOURS_START,
     CONFIG_EMAIL_KEY,
     CONFIG_EXPERIMENTAL_KEY,
     CONFIG_PASSWORD_KEY,
@@ -201,6 +203,14 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                         CONFIG_SCAN_INTERVAL_KEY, 120
                     ),
                 ): vol.All(vol.Coerce(int), vol.Range(min=60, max=1440)),
+                vol.Required(
+                    CONFIG_DARK_HOURS_START,
+                    default=self.config_entry.options.get(CONFIG_DARK_HOURS_START, 1),
+                ): vol.All(vol.Coerce(int), vol.Range(min=0, max=23)),
+                vol.Required(
+                    CONFIG_DARK_HOURS_END,
+                    default=self.config_entry.options.get(CONFIG_DARK_HOURS_END, 5),
+                ): vol.All(vol.Coerce(int), vol.Range(min=0, max=23)),
             }
         )
 

--- a/custom_components/lynkco/const.py
+++ b/custom_components/lynkco/const.py
@@ -8,12 +8,14 @@ STORAGE_REFRESH_TOKEN_KEY = "refresh_token"
 DATA_UPDATE_COORDINATOR = "data_update_coordinator"
 
 # Config keys
-CONFIG_EXPERIMENTAL_KEY = "experimental"
-CONFIG_SCAN_INTERVAL_KEY = "scan_interval"
 CONFIG_VIN_KEY = "vin"
 CONFIG_EMAIL_KEY = "email"
 CONFIG_PASSWORD_KEY = "password"
 CONFIG_2FA_KEY = "2fa"
+CONFIG_EXPERIMENTAL_KEY = "experimental"
+CONFIG_SCAN_INTERVAL_KEY = "scan_interval"
+CONFIG_DARK_HOURS_START = "dark_hours_start"
+CONFIG_DARK_HOURS_END = "dark_hours_end"
 
 # Hass data constants
 DATA_EXPECTED_STATE = "expected_state_monitor"

--- a/custom_components/lynkco/manifest.json
+++ b/custom_components/lynkco/manifest.json
@@ -12,5 +12,5 @@
         "requests>=2.31.0",
         "pkce>=1.0.3"
     ],
-    "version": "1.3.1"
+    "version": "1.4.0"
 }

--- a/custom_components/lynkco/strings.json
+++ b/custom_components/lynkco/strings.json
@@ -43,7 +43,8 @@
         "data": {
           "experimental": "Enable experimental features (use at your own risk)",
           "scan_interval": "Scan Interval (minutes)",
-          "refresh_interval": "Refresh Interval (minutes) for fetching updates"
+          "dark_hours_start": "Start of dark hours interval (not automatic updates during interval)",
+          "dark_hours_end": "End of dark hours interval (not automatic updates during interval)"
         }
       }
     }

--- a/custom_components/lynkco/translations/en.json
+++ b/custom_components/lynkco/translations/en.json
@@ -41,9 +41,10 @@
         "title": "Lynk & Co Integration Settings",
         "description": "Configure your Lynk & Co integration settings.",
         "data": {
-          "experimental": "Enable experimental features (use at your own risk)",
+          "experimental": "Enable experimental features (use at your own risk, see README)",
           "scan_interval": "Scan Interval (minutes)",
-          "refresh_interval": "Refresh Interval (minutes) for fetching updates"
+          "dark_hours_start": "Start of dark hours interval (not automatic updates during interval)",
+          "dark_hours_end": "End of dark hours interval (not automatic updates during interval)"
         }
       }
     }

--- a/custom_components/lynkco/translations/en.json
+++ b/custom_components/lynkco/translations/en.json
@@ -41,7 +41,7 @@
         "title": "Lynk & Co Integration Settings",
         "description": "Configure your Lynk & Co integration settings.",
         "data": {
-          "experimental": "Enable experimental features (use at your own risk, see README)",
+          "experimental": "Enable experimental features (use at your own risk)",
           "scan_interval": "Scan Interval (minutes)",
           "dark_hours_start": "Start of dark hours interval (not automatic updates during interval)",
           "dark_hours_end": "End of dark hours interval (not automatic updates during interval)"

--- a/release-notes
+++ b/release-notes
@@ -1,2 +1,3 @@
-1.3.1
-Fixed handling of re-authentication in UI when update_data fails due to token not valid
+1.4.0
+Added option to set dark hours where automatic updates should be disabled.
+Minor improvements to README.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to set dark hours for disabling automatic updates in the Lynkco custom component.

- **Documentation**
  - Added "Options Flow" section in README for configuring options through the Home Assistant UI.
  - Clarified `start_engine` service behavior and updated "Vehicle is Running" binary sensor description.

- **Updates**
  - Updated Lynkco custom component version to 1.4.0.
  - Revised descriptions for `experimental`, `scan_interval`, `dark_hours_start`, and `dark_hours_end` settings in translations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->